### PR TITLE
Fix label 30 preamble /EA "DS" code

### DIFF
--- a/research/30/forward-slash-EA.md
+++ b/research/30/forward-slash-EA.md
@@ -43,8 +43,7 @@ Flight was from Austin (AUS) to San Francisco (SFO).
 ## Acronyms / Codes
 
 - EA - Estimated Arrival
-- DSK - unknown, but related to the destination airport
-- DSM - unknown
+- DS - Destination Airport ICAO
 - SK - unknown
 
 ## Analysis


### PR DESCRIPTION
I didn't get the "DS" code right in the first patch. I now understand it will be the destination airport ICAO.